### PR TITLE
HF-FE-5, HF-FE-6, General FE: Añadir categoriaa podcast y tags a episodes

### DIFF
--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -5,9 +5,22 @@
       <div class="publish col-lg-10 col-md-9 col-sm-12 p-0">
         <div class="profile-content p-5">
           <div class="row w-80">
-            <TopBar />
+            <TopBar @search="search"/>
+        </div>
+        <!-- If user is searching -->
+        <div v-if="searching">
+          <h1 class="ps-5">Search results. <a @click="searching=false" style="color: rgb(206, 206, 206); cursor: pointer;">Go back.</a></h1>
+          <div class="featured">
+            <h2 class="ps-5">Podcasts</h2>
+            <PodcastList :podcastList="podcastSearchList" />
           </div>
-          <div class="profile-info" v-if="user">
+          <div class="featured">
+            <h2 class="ps-5">Authors</h2>
+            <UserList :userList="userSearchList" />
+          </div>
+        </div>
+
+          <div v-else class="profile-info" v-if="user">
             <img src="../assets/redpanda.jpg" alt="profile" class="profile-img rounded-circle"
               style="width: 15vw; max-width: 15em;" />
             <div style="display: inline-block;" class="ms-4">
@@ -49,6 +62,7 @@ import Sidebar from '../components/Sidebar.vue'
 import EpisodeList from '../components/EpisodeList.vue'
 import PodcastList from '../components/PodcastList.vue'
 import TopBar from '../components/TopBar.vue'
+import UserList from '../components/UserList.vue'
 import axios from 'axios'
 
 export default {
@@ -56,6 +70,7 @@ export default {
     Sidebar,
     EpisodeList,
     PodcastList,
+    UserList,
     TopBar
   },
   data() {
@@ -66,10 +81,52 @@ export default {
       isMyProfile: false,
       myPodcasts: [],
       favoriteList: [],
-      watchLaterList: []
+      watchLaterList: [],
+      searching: false,
+      podcastSearchList: [],
+      userSearchList: [],
     }
   },
   methods: {
+    search(nameQuery, authorQuery) {
+      console.log(nameQuery, authorQuery)
+      if (nameQuery) {
+        this.getName(nameQuery)
+      } else {
+        this.podcastSearchList = []
+      }
+      if (authorQuery) {
+        this.getAuthor(authorQuery)
+      } else {
+        this.userSearchList = []
+      }
+        
+      this.searching = true;
+    },
+    getName(nameQuery) {
+      const pathSearch = import.meta.env.VITE_API_URL + "/search/podcast/" + nameQuery
+
+      axios.get(pathSearch)
+        .then((res) => {
+          this.podcastSearchList = res.data
+        })
+        .catch((error) => {
+          this.podcastSearchList = []
+          console.error(error)
+        })
+    },
+    getAuthor(authorQuery) {
+      const pathSearch = import.meta.env.VITE_API_URL + "/search/user/" + authorQuery
+
+      axios.get(pathSearch)
+        .then((res) => {
+          this.userSearchList = res.data
+        })
+        .catch((error) => {
+          this.userSearchList = []
+          console.error(error)
+        })
+    },
     getUserInfo() {
       const path = import.meta.env.VITE_API_URL + '/user/' + this.userId
 
@@ -180,6 +237,7 @@ export default {
 
     }
   },
+  
   created() {
     this.userId = this.$route.params.id;
     if (this.$store.state.userIsLoggedIn) {

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -76,7 +76,7 @@ export default {
   data() {
     return {
       user: null,
-      userId: null,
+      userIdLooking: null,
       myId: null,
       isMyProfile: false,
       myPodcasts: [],
@@ -128,11 +128,23 @@ export default {
         })
     },
     getUserInfo() {
-      const path = import.meta.env.VITE_API_URL + '/user/' + this.userId
+      
+      // Reiniciar variables relacionadas con el perfil
+      this.user = null;
+      this.isMyProfile = false;
+      this.myPodcasts = [];
+      this.favoriteList = [];
+      this.watchLaterList = [];
+
+      this.getIdProfile()
+      const path = import.meta.env.VITE_API_URL + '/user/' + this.userIdLooking
 
       const axiosConfig = {
         withCredentials: true
       }
+
+      
+      
 
       axios.get(path)
         .then(response => {
@@ -152,14 +164,14 @@ export default {
       const axiosConfig = {
         withCredentials: true
       }
-
-
       axios.get(userPath, axiosConfig).then((res) => {
         this.myId = res.data.logged_in_as;
-        if (this.myId === this.userId) {
+        if (this.myId === this.userIdLooking) {
           this.isMyProfile = true;
           this.getFavorites()
           this.getWatchLater()
+        }else{
+          this.isMyProfile = false;
         }
       })
         .catch((error) => {
@@ -167,7 +179,7 @@ export default {
         });
     },
     getMyPodcasts() {
-      const path = import.meta.env.VITE_API_URL + '/user/created_podcasts/' + this.userId
+      const path = import.meta.env.VITE_API_URL + '/user/created_podcasts/' + this.userIdLooking
 
       axios.get(path)
         .then((res) => {
@@ -234,17 +246,24 @@ export default {
         .catch((error) => {
           console.log(error)
         })
-
+    },
+    
+  },
+  watch: {
+    '$route.params.id': function (newId, oldId) {
+      // Se llama cuando el parámetro de la ruta cambia
+      this.userIdLooking = newId;
+      this.getUserInfo();
     }
   },
-  
   created() {
-    this.userId = this.$route.params.id;
+    this.userIdLooking = this.$route.params.id;
     if (this.$store.state.userIsLoggedIn) {
       this.getIdProfile()
+      this.getUserInfo()
     }
     // Uncomment when endpoints are ready
-    this.getUserInfo()
+    
 
 
   }

--- a/src/views/PublishEpisode.vue
+++ b/src/views/PublishEpisode.vue
@@ -52,7 +52,7 @@
 
                   <!-- <image-cropper v-model="episodeImage" /> -->
 
-                  <button type="submit" class="btn-submit-bold btn btn-dark mt-3" style="width: 100%;">Post Episode</button>
+                  <button type="submit" class="btn-submit-bold btn btn-dark mt-3" style="width: 100%;" :disabled="loading">Post Episode</button>
                 </form>
               </div>
             </div>
@@ -80,11 +80,17 @@ export default {
       description: "",
       tags: [],
       audio: null,
-      tagInput: null
+      tagInput: null,
+      loading: false
     };
   },
   methods: {
     onSubmit() {
+      if (this.loading){
+        return;
+      }
+
+      this.loading = true;
       const tags = this.tagInput.split(/[, ]+/).filter(tag => tag.trim() !== '');
       console.log('Etiquetas:', tags);
 
@@ -102,17 +108,17 @@ export default {
       // formData.append('episodeImage', this.episodeImage);
       const path = import.meta.env.VITE_API_URL + '/podcasts/' + this.$route.params.id + '/episodes' 
       
-      axios.post(path, formData, axiosConfig, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
-      })
+      axios.post(path, formData, axiosConfig)
         .then((response) => {
           console.log(response);
           alert('Episode published successfully');
+          this.backToHome()
         })
         .catch((error) => {
           console.log(error);
+        })
+        .finally(() => {
+          this.loading = false; 
         });
     },
     onFileChange() {
@@ -121,6 +127,9 @@ export default {
     handleTagInput() {
       const tags = this.tagInput.split(/[, ]+/).filter(tag => tag.trim() !== '');
       this.tags = tags;
+    },
+    backToHome() {
+      this.$router.push('/')
     },
   },
 };

--- a/src/views/PublishPodcast.vue
+++ b/src/views/PublishPodcast.vue
@@ -35,25 +35,36 @@
                                     </div>
                                     <div class="mb-3"></div>
                                 
-                                    <div class="form-group">
-                                        <label for="etiquetas" class="label">Tags</label>
-                                        <input
-                                            type="text"
-                                            class="form-control"
-                                            id="tags"
-                                            v-model="tagInput"
-                                            @input="handleTagInput"
-                                        />
-                                        <div class="mb-3"></div>
-                                        <div class="tags-container">
-                                        <div class="tag" v-for="(tag, index) in tags" :key="index" >
-                                            {{ tag }}
+                                    
+                                    <!--
+                                    <div>
+                                        <h2>Selecciona una categoría</h2>
+                                        <div class="categorias-container">
+                                        <div v-for="categoria in this.categories" :key="categoria.title">
+                                            <button :class="{ 'selected': categoria.title === category }"  @click="seleccionarCategoria(categoria.title)" >
+                                                {{ categoria.title }}
+                                            </button>
                                         </div>
+                                        </div>
+                                        <p>Categoría seleccionada: {{ this.category }}</p>
+                                    </div>
+                                -->
+                                    <div>
+                                        <h2>Selecciona una categoría</h2>
+                                        <div class="categorias-container">
+                                            <button class="btn-category"
+                                                v-for="categoria in categories"
+                                                :key="categoria.title"
+                                                :class="{ 'selected': categoria.title === this.category }"
+                                                @click="seleccionarCategoria(categoria.title)"
+                                            >
+                                                {{ categoria.title }}
+                                            </button>
                                         </div>
                                     </div>
                                     <div class="mb-3"></div>
                                 
-                                    <button type="submit" class="btn-submit-bold btn btn-dark mt-3" style="width: 100%;"  @click="onSubmit">Publish Podcast</button>
+                                    <button type="submit" class="btn-submit-bold btn btn-dark mt-3" style="width: 100%;"  @click="onSubmit" :disabled="loading">Publish Podcast</button>
                                 </form>
                             </div>
                         </div>
@@ -79,8 +90,11 @@ export default {
             title: null,
             summary: null,
             description: null,
-            tags: [],
-            tagInput: null
+            category: null,
+            categories: [],
+            loading: false,
+            //tags: [],
+            //tagInput: null
         };
     },
     methods: {
@@ -88,8 +102,13 @@ export default {
             this.image_url = blob;
         },
         onSubmit() {
-            const tags = this.tagInput.split(/[, ]+/).filter(tag => tag.trim() !== '');
-            console.log('Etiquetas:', tags);
+            //const tags = this.tagInput.split(/[, ]+/).filter(tag => tag.trim() !== '');
+            //console.log('Etiquetas:', tags);
+            if (this.loading){
+                return;
+            }
+
+            this.loading = true;
 
             var formData = new FormData();
 
@@ -97,14 +116,16 @@ export default {
             formData.append("name", this.title)
             formData.append("summary", this.summary)
             formData.append("description", this.description)
-            formData.append("tags", this.tags)
+            //formData.append("tags", this.tags)
+            formData.append("category", this.category)
 
             const parameters = {
                 cover: this.image_url,
                 name: this.title,
                 summary: this.summary,
                 descripcion: this.description,
-                tags: this.tags
+                //tags: this.tags
+                category: this.category
             }
 
 
@@ -127,6 +148,9 @@ export default {
                     alert('Error posting podcast')
                     console.error(error)
                 })
+                .finally(() => {
+                    this.loading = false; 
+                });
         },
         handleTagInput() {
             const tags = this.tagInput.split(/[, ]+/).filter(tag => tag.trim() !== '');
@@ -134,7 +158,23 @@ export default {
         },
         backToHome() {
             this.$router.push('/')
-        }
+        },
+        getCategories() {
+            const path = import.meta.env.VITE_API_URL + '/categories'
+            axios.get(path).then((res) => {
+                this.categories = res.data
+            })
+            .catch((error)=> {
+                alert('Error getting categories')
+                console.error(error)
+            })
+        },
+        seleccionarCategoria(tituloCategoria) {
+            this.category = tituloCategoria;
+        },
+    },
+    created(){
+        this.getCategories()
     }
 };
 </script>
@@ -158,6 +198,48 @@ export default {
   padding: 4px 8px;
   font-size: 0.9rem;
   cursor: pointer;
+}
+/*
+.btn-category {
+  padding: 0.6rem 2.5rem;
+  border-radius: 50px;
+  font-size: 1.1rem;
+  background-color: var(--category-color);
+  border: 1px solid var(--category-border-color);
+  color: var(--category-text-color);
+  cursor: pointer;
+  font-weight: normal; 
+}
+
+
+.btn-category.selected {
+  background-color: var(--category-selected-color);
+  color: #fff;
+}
+*/
+
+.btn-category {
+  padding: 0.25rem 0.85rem; 
+  border-radius: 8px;
+  font-size: 1rem;
+  background-color: #e0e0e0; 
+  border: 1px solid #ccc;
+  color: #333;
+  cursor: pointer;
+  font-weight: normal;
+  margin: 0.1rem;
+}
+
+.btn-category.selected {
+  background-color: #646cff;
+  color: #fff; 
+}
+.categorias-container {
+  text-align: center; /* Centra los botones */
+}
+
+.categorias-container button {
+  margin: 7px; /* Agrega un pequeño margen entre los botones */
 }
 </style>
 

--- a/src/views/VisualizeEpisode.vue
+++ b/src/views/VisualizeEpisode.vue
@@ -6,9 +6,22 @@
             <!-- Main content-->
             <div class="visualize-content col-lg-10 col-md-9 col-sm-12 p-0  ">
                 <div class="row w-100 p-5">
-                    <TopBar />
+                    <TopBar @search="search"/>
                 </div>
-                <div class="row p-5 w-100">
+                <!-- If user is searching -->
+                <div v-if="searching">
+                    <h1 class="ps-5">Search results. <a @click="searching=false" style="color: rgb(206, 206, 206); cursor: pointer;">Go back.</a></h1>
+                    <div class="featured">
+                        <h2 class="ps-5">Podcasts</h2>
+                        <PodcastList :podcastList="podcastSearchList" />
+                    </div>
+                    <div class="featured">
+                        <h2 class="ps-5">Authors</h2>
+                        <UserList :userList="userSearchList" />
+                    </div>
+                </div>
+
+                <div v-else class="row p-5 w-100">
 
                     <!-- Info section -->
                     <div class="col-12 col-sm-12 col-md-12 col-lg-12">
@@ -148,6 +161,8 @@ import Comment from '../components/Comment.vue';
 import CommentForm from '../components/CommentForm.vue';
 import TopBar from '../components/TopBar.vue';
 import ProgressBar from '../components/ProgressBar.vue';
+import UserList from '../components/UserList.vue';
+import PodcastList from '../components/PodcastList.vue';
 import axios from 'axios'
 
 export default {
@@ -157,60 +172,63 @@ export default {
         CommentForm,
         ProgressBar,
         TopBar,
+        PodcastList,
+        UserList,
     },
     data() {
         return {
-            // episode:{ 
-            //     id: 1, 
-            //     title: 'Intro', 
-            //     episodeImage: "/src/assets/podcasts/MMCD.jpg", 
-            //     description: "Pequeño speech de Cruzzi hablando de la luna, y de la importancia de las Palmas al haberse criado allí.", 
-            //     audio_url: '/src/assets/audio/Moonlight_audio.mp3', 
-            //     tags: ["Intro", "Cruzzi", "Moonlight"], 
-            //     comments: [
-            //     {
-            //         date: new Date(),
-            //         text: "¡Este episodio fue increíblemente informativo! Me encantó cómo los anfitriones profundizaron en el tema y proporcionaron datos detallados que realmente ampliaron mi comprensión. ¡Aprendí mucho en solo unos minutos!",
-            //         replies: [
-            //             {
-            //             date: new Date(),
-            //             text: "La calidad del sonido en este episodio es excepcional. La producción está muy bien hecha, lo que hizo que la experiencia auditiva fuera muy agradable. ¡Se nota el esfuerzo que pusieron en la edición para garantizar una excelente calidad!",
-            //             replies: [
-            //                 {
-            //                 date: new Date(),
-            //                 text: "Teneis razón ambos, me encantó el episodio!!",
-            //                 replies: [],
-            //                 },
-            //             ],
-            //             },
-            //             {
-            //             date: new Date(),
-            //             text: "Tienes razón este episodio es un 10!",
-            //             replies: [],
-            //             },
-            //         ]},
-            //         {
-            //         date: new Date(),
-            //         text: "Los invitados en este episodio aportaron perspectivas fascinantes. Me encantó escuchar diferentes voces y opiniones sobre el tema. Fue genial ver cómo los anfitriones facilitaron la conversación de manera que todos pudieron expresar sus ideas de manera clara y concisa.",
-            //         replies: [],
-            //         },
-            //     ],
-            //     author: "Cruz Cafuné",
-            //     audioElement: null, 
-            //     isLiked: false 
-            // },
-            // currentEpisode: null,
-            // tagColors: {},
             episode: {},
             episode_edited: {},
             audio_edited: null,
             streamLater: [],
             editting: false,
             isAuthor: false,
+            podcastSearchList: [],
+            userSearchList: [],
+            searching: false
         };
 
     },
     methods: {
+        search(nameQuery, authorQuery) {
+            console.log(nameQuery, authorQuery)
+            if (nameQuery) {
+                this.getName(nameQuery)
+            } else {
+                this.podcastSearchList = []
+            }
+            if (authorQuery) {
+                this.getAuthor(authorQuery)
+            } else {
+                this.userSearchList = []
+            }
+                
+            this.searching = true;
+        },
+        getName(nameQuery) {
+            const pathSearch = import.meta.env.VITE_API_URL + "/search/podcast/" + nameQuery
+
+            axios.get(pathSearch)
+            .then((res) => {
+                this.podcastSearchList = res.data
+            })
+            .catch((error) => {
+                this.podcastSearchList = []
+                console.error(error)
+            })
+        },
+        getAuthor(authorQuery) {
+            const pathSearch = import.meta.env.VITE_API_URL + "/search/user/" + authorQuery
+
+            axios.get(pathSearch)
+            .then((res) => {
+                this.userSearchList = res.data
+            })
+            .catch((error) => {
+                this.userSearchList = []
+                console.error(error)
+            })
+        },
         togglePlayback(episode) {
             if (this.currentEpisode === episode) {
                 // Si el mismo episodio está en reproducción, detén la reproducción

--- a/src/views/VisualizePodcast.vue
+++ b/src/views/VisualizePodcast.vue
@@ -222,7 +222,7 @@ export default {
             axios.get(pathEpisodes)
                 .then((res) => {
                     this.podcast.episodes = res.data
-                    console.log(this.podcast)
+                    console.log("TAGS:",this.podcast.episodes[1].tags)
                 })
                 .catch((error) => {
                     console.log(error)

--- a/src/views/VisualizePodcast.vue
+++ b/src/views/VisualizePodcast.vue
@@ -6,9 +6,22 @@
             <!-- Main content-->
             <div class="visualize-content col-lg-10 col-md-9 col-sm-12 p-0  ">
                 <div class="row w-100 p-5">
-                    <TopBar />
+                    <TopBar @search="search"/>
                 </div>
-                <div class="row p-5 w-100">
+                <!-- If user is searching -->
+                <div v-if="searching">
+                    <h1 class="ps-5">Search results. <a @click="searching=false" style="color: rgb(206, 206, 206); cursor: pointer;">Go back.</a></h1>
+                    <div class="featured">
+                        <h2 class="ps-5">Podcasts</h2>
+                        <PodcastList :podcastList="podcastSearchList" />
+                    </div>
+                    <div class="featured">
+                        <h2 class="ps-5">Authors</h2>
+                        <UserList :userList="userSearchList" />
+                    </div>
+                </div>
+
+                <div v-else class="row p-5 w-100">
                     <div class="col-12 col-sm-12 col-md-12 col-lg-12">
                         <div class="contenedor-reducido mb-5">
 
@@ -86,6 +99,8 @@ import Sidebar from '../components/Sidebar.vue';
 import Episode from '../components/Episode.vue';
 import ProgressBar from '../components/ProgressBar.vue';
 import TopBar from '../components/TopBar.vue';
+import UserList from '../components/UserList.vue';
+import PodcastList from '../components/PodcastList.vue';
 import axios from 'axios'
 
 export default {
@@ -94,16 +109,60 @@ export default {
         Episode,
         ProgressBar,
         TopBar,
+        PodcastList,
+        UserList,
     },
     data() {
         return {
             podcast: {},
             podcast_edited: {},
             isAuthor: false,
-            editting: false
+            editting: false,
+            searching: false,
+            podcastSearchList: [],
+            userSearchList: [],
         };
     },
     methods: {
+        search(nameQuery, authorQuery) {
+            console.log(nameQuery, authorQuery)
+            if (nameQuery) {
+                this.getName(nameQuery)
+            } else {
+                this.podcastSearchList = []
+            }
+            if (authorQuery) {
+                this.getAuthor(authorQuery)
+            } else {
+                this.userSearchList = []
+            }
+                
+            this.searching = true;
+        },
+        getName(nameQuery) {
+            const pathSearch = import.meta.env.VITE_API_URL + "/search/podcast/" + nameQuery
+
+            axios.get(pathSearch)
+            .then((res) => {
+                this.podcastSearchList = res.data
+            })
+            .catch((error) => {
+                this.podcastSearchList = []
+                console.error(error)
+            })
+        },
+        getAuthor(authorQuery) {
+            const pathSearch = import.meta.env.VITE_API_URL + "/search/user/" + authorQuery
+
+            axios.get(pathSearch)
+            .then((res) => {
+                this.userSearchList = res.data
+            })
+            .catch((error) => {
+                this.userSearchList = []
+                console.error(error)
+            })
+        },
         getPodcast() {
             const podcastId = this.$route.params.id;
             const pathPodcast = import.meta.env.VITE_API_URL + `/podcasts/${podcastId}`;


### PR DESCRIPTION
Realizo las siguientes tareas:
- Hotfix FE 5: Ahora podremos realizar búsquedas usando la barra de búsqeuda en todos los componentes y views que la contengan, realizando una búsqueda correcta.
- Hotfix FE 6: Soluciono el problema que nos aparecía cuando se modificaba el id del endpoint de profile. Antes cuando se modificaba ese valor el contenido visual no se actualizaba, ahora he utilizado un watcher de esa variable encontrada en el endpoint para que cada vez que se modifique tambien nos muestre el contenido adecuado.
- General FE: Ahora he añadido la opción de agreagar la categoría al publicar un Podcast, quitando las tags de los podcasts ya que en BE no lo contemplaban pero si contemplaban la categoría del podcast, por lo tanto cuando creamos ahora un podcast seleccionaremos una categoría. Por otro lado al añadir un episodio este tendrá unas tags que podremos ver en el caso que tenga tags asignadas dicho episodio.