### PR TITLE
HF-FE-10

### DIFF
--- a/src/components/Episode.vue
+++ b/src/components/Episode.vue
@@ -36,7 +36,7 @@
     </div>
 
     <div v-if="currentEpisode">
-        <ProgressBar ref="progressBar" />
+        <ProgressBar ref="progressBar" :url="currentEpisode.audio_url" />
     </div>
 </template>
 
@@ -90,21 +90,21 @@ export default {
         // TODO: Descomentar y linkear con el componente ProgressBar
         playEpisode(episode) {
             this.currentEpisode = episode
-            this.$nextTick(() => {
-                // Use $nextTick to wait for the ProgressBar component to be mounted
-                const progressBar = this.$refs.progressBar;
+            // this.$nextTick(() => {
+            //     // Use $nextTick to wait for the ProgressBar component to be mounted
+            //     const progressBar = this.$refs.progressBar;
 
-                if (progressBar) {
-                    this.$refs.progressBar.setAudioUrl(episode.audio_url);
-                    this.$refs.progressBar.setCoverUrl(this.podcastImage);
-                    this.$refs.progressBar.setTitlePodcast(this.podcastName);
-                    this.$refs.progressBar.setTitleEpisode(episode.title)
-                    this.$refs.progressBar.play();
-                    this.$refs.progressBar.initSlider();
-                } else {
-                    console.error('ProgressBar component or setAudioUrl method not found.');
-                }
-            });
+            //     if (progressBar) {
+            //         this.$refs.progressBar.setAudioUrl(episode.audio_url);
+            //         this.$refs.progressBar.setCoverUrl(this.podcastImage);
+            //         this.$refs.progressBar.setTitlePodcast(this.podcastName);
+            //         this.$refs.progressBar.setTitleEpisode(episode.title)
+            //         this.$refs.progressBar.play();
+            //         this.$refs.progressBar.initSlider();
+            //     } else {
+            //         console.error('ProgressBar component or setAudioUrl method not found.');
+            //     }
+            // });
         },
         // playEpisode(episode) {
         //     const audioElement = new Audio(episode.audio_url);

--- a/src/components/ProgressBar.vue
+++ b/src/components/ProgressBar.vue
@@ -3,7 +3,7 @@
         <div id="audio-player-root w-100 p-0 m-0">
             <div>
                 <audio style="display:none" ref="player" :id="playerid">
-                    <source :src="audioUrl" type="audio/mpeg" />
+                    <source :src="url" type="audio/mpeg" />
                 </audio>
             </div>
             <div class="player-content w-full rounded-lg shadow-lg m-0 p-0">
@@ -64,36 +64,13 @@ export default {
             audioLoaded: false,
             isPlaying: false,
             episodeToken: "",
-            audioUrl: "../src/assets/audio/episodes/episode1.mp3",
+            // audioUrl: "../src/assets/audio/episodes/episode1.mp3",
             titlePodcast: "",
             titleEpisode: "",
             coverImg: null
         };
     },
     methods: {
-        consoleLogTest() {
-            console.log("Test");
-        },
-        setAudioUrl(audioUrl) {
-            this.audioUrl = audioUrl;
-        },
-        setCoverUrl(coverUrl) {
-            this.coverImg = coverUrl;
-        },
-        setTitlePodcast(title) {
-            this.titlePodcast = title;
-        },
-        setTitleEpisode(title) {
-            this.titleEpisode = title;
-        },
-        fetchAudio() {
-            axios.get('/api/episodes/' + this.episodeToken + '/audio').then((response) => {
-                this.audioUrl = response.data.url;
-            })
-            .catch((error) => {
-                console.log(error);
-            });
-        },
         initSlider() {
             var audio = this.$refs.player;
             if (audio) {
@@ -163,9 +140,10 @@ export default {
         }
     },
     mounted: function () {
-        //this.fetchAudio(); // TODO: Descomentar cuando esté la parte de backend preparada
         this.$nextTick(function () {
             var audio = this.$refs.player;
+            this.isPlaying = true;
+            audio.play();
             audio.addEventListener("loadedmetadata", function (e) {
                 this.initSlider();
             }.bind(this));
@@ -176,18 +154,20 @@ export default {
                 if (this.isPlaying) {
                     var audio = this.$refs.player;
                     this.initSlider();
-                    if (!this.listenerActive) {
-                        this.listenerActive = true;
-                        audio.addEventListener("timeupdate", this.playbackListener);
-                    }
+                    this.listenerActive = true;
+                    audio.addEventListener("timeupdate", this.playbackListener);
                 }
             });
             this.$watch("playbackTime", function () {
-                var audio = this.$refs.player;
                 var diff = Math.abs(this.playbackTime - this.$refs.player.currentTime);
                 if (diff > 0.01) {
                     this.$refs.player.currentTime = this.playbackTime;
                 }
+            });
+            this.$watch("url", function () {
+                this.$refs.player.load();
+                this.isPlaying = true;
+                this.$refs.player.play();
             });
         });
     }


### PR DESCRIPTION

Solucionado: Anteriormente, al hacer clic en el botón de reproducción (en el componente Episode.vue) de un episodio específico que no se estaba reproduciendo mientras otro episodio estaba en curso, no comenzaba a reproducirse el episodio deseado de inmediato. En lugar de eso, era necesario hacer clic varias veces para iniciar la reproducción del audio del episodio seleccionado. 

Se ha corregido este problema, y ahora, al hacer clic en el botón de reproducción, el audio del episodio elegido comienza a reproducirse de manera inmediata y consistente, incluso si otro episodio está reproduciéndose en ese momento.